### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/LSW3/08cefed4-c82b-4836-9c8c-05321816f345/5e77386f-e5f6-4c5b-8cdb-1d18890253f8/_apis/work/boardbadge/d047ed50-20b8-4a04-8755-0fa29076ba19)](https://dev.azure.com/LSW3/08cefed4-c82b-4836-9c8c-05321816f345/_boards/board/t/5e77386f-e5f6-4c5b-8cdb-1d18890253f8/Microsoft.RequirementCategory)
 # Calculator
 <!---![Azure DevOps builds](https://img.shields.io/azure-devops/build/LSW3/19ca2c75-c209-4119-89b0-926bb0c5c3ab/5) --->
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#916](https://dev.azure.com/LSW3/08cefed4-c82b-4836-9c8c-05321816f345/_workitems/edit/916). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.